### PR TITLE
Refactor access_NR_table function for name range handling

### DIFF
--- a/src/migration_tool/outils.py
+++ b/src/migration_tool/outils.py
@@ -44,51 +44,44 @@ def create_table_of_contents(wb_values) -> Dict[str, int]:
     return dict(zip(_keys, _values))
 
 
-def access_NR_table(pyxl_NR, sheets=None) -> tuple[pd.DataFrame, list | None]:
+def access_NR_table(pyxl_NR, old_sheet_names: list[str] | None = None) -> tuple[pd.DataFrame, list]:
     """Access names, cell references and coordinates of each name range from the python object containing name ranges.
     Returns a (pandas) DataFrame.
     There were some VSME samples that, after processing in openpyxl, returned wrong sheet references for their name ranges (e.g. "[1]General Information" instead of "General Information");
     To handle this, a list of issues (str explaining where the issue is) is returned alongside the DataFrame."""
 
-    list_NR = list(pyxl_NR.keys())
-    list_sheets = []
-    list_ranges = []
-    list_shapes = []
+    rows: list[tuple[str, str | None, str | None, shapes]] = []
+    issues: list[str] = []
 
-    list_NR_issues = []
-
-    for NR in list_NR:
-        list_temp = pyxl_NR[NR].attr_text.split("!")[0].replace("'", "")
-        if sheets is not None and list_temp not in sheets:
-            list_NR_issues.append(
-                f"Name range '{NR}' refers to sheet '{list_temp}' which is not present in the old workbook. This name range has been ignored in the migration."
+    for NR, dn in pyxl_NR.items():
+        try:
+            destinations = list(dn.destinations)
+        except AttributeError:
+            issues.append(
+                f"Name range '{NR}' has an unreadable destination (value: {dn.attr_text!r}). This name range has been ignored in the migration."
             )
-            list_temp = None
-        list_sheets.append(list_temp)
+            rows.append((NR, None, None, shapes(None)))
+            continue
 
-        rng_temp = pyxl_NR[NR].attr_text.split("!")[1]
-        if rng_temp == "#REF":  # handling #REF name ranges (in Translations sheet)
-            rng_temp = None
-        list_ranges.append(rng_temp)
+        if len(destinations) != 1:
+            issues.append(
+                f"Name range '{NR}' has {len(destinations)} destinations (expected 1; value: {dn.attr_text!r}). This name range has been ignored in the migration."
+            )
+            rows.append((NR, None, None, shapes(None)))
+            continue
 
-    for rng in list_ranges:
-        if rng is None:
-            list_shapes.append(shapes(None))
-        else:
-            list_shapes.append(shapes(range_boundaries(rng)))
+        sheet, rng = destinations[0]
+        if old_sheet_names is not None and sheet not in old_sheet_names:
+            issues.append(
+                f"Name range '{NR}' refers to sheet '{sheet}' which is not present in the old workbook. This name range has been ignored in the migration."
+            )
+            sheet = None
 
-    df_populated = pd.DataFrame(
-        {
-            "name_ranges": list_NR,
-            "sheets": list_sheets,
-            "cell_ranges": list_ranges,
-            "cell_shapes": list_shapes,
-        }
-    )
-    if sheets is not None:
-        return df_populated, list_NR_issues
-    else:
-        return df_populated, None
+        rng = rng or None
+        rows.append((NR, sheet, rng, shapes(range_boundaries(rng)) if rng else shapes(None)))
+
+    df_populated = pd.DataFrame(rows, columns=["name_ranges", "sheets", "cell_ranges", "cell_shapes"])
+    return df_populated, issues
 
 
 def access_missingNR_table(df_missingNR, version_cell):

--- a/src/migration_tool/outils.py
+++ b/src/migration_tool/outils.py
@@ -44,7 +44,9 @@ def create_table_of_contents(wb_values) -> Dict[str, int]:
     return dict(zip(_keys, _values))
 
 
-def access_NR_table(pyxl_NR, old_sheet_names: list[str] | None = None) -> tuple[pd.DataFrame, list]:
+def access_NR_table(
+    pyxl_NR, old_sheet_names: list[str] | None = None
+) -> tuple[pd.DataFrame, list]:
     """Access names, cell references and coordinates of each name range from the python object containing name ranges.
     Returns a (pandas) DataFrame.
     There were some VSME samples that, after processing in openpyxl, returned wrong sheet references for their name ranges (e.g. "[1]General Information" instead of "General Information");
@@ -78,9 +80,13 @@ def access_NR_table(pyxl_NR, old_sheet_names: list[str] | None = None) -> tuple[
             sheet = None
 
         rng = rng or None
-        rows.append((NR, sheet, rng, shapes(range_boundaries(rng)) if rng else shapes(None)))
+        rows.append(
+            (NR, sheet, rng, shapes(range_boundaries(rng)) if rng else shapes(None))
+        )
 
-    df_populated = pd.DataFrame(rows, columns=["name_ranges", "sheets", "cell_ranges", "cell_shapes"])
+    df_populated = pd.DataFrame(
+        rows, columns=["name_ranges", "sheets", "cell_ranges", "cell_shapes"]
+    )
     return df_populated, issues
 
 

--- a/src/migration_tool/tool.py
+++ b/src/migration_tool/tool.py
@@ -91,11 +91,10 @@ def migrate_workbook(
     version_cell = old_wb_obj["Introduction"].cell(row=1, column=3).value
     version_cell_new = new_wb_empty["Introduction"].cell(row=1, column=3).value
 
-    old_wb_sheets = [sheet.title for sheet in old_wb_obj.worksheets]
+    old_wb_sheet_names = [sheet.title for sheet in old_wb_obj.worksheets]
 
-    df_old, sheets_issues = access_NR_table(old_wb_obj.defined_names, old_wb_sheets)
-    if isinstance(sheets_issues, list) and sheets_issues:
-        list_migrationissues.extend(sheets_issues)
+    df_old, sheets_issues = access_NR_table(old_wb_obj.defined_names, old_wb_sheet_names)
+    list_migrationissues.extend(sheets_issues)
     df_new, _ = access_NR_table(new_wb_empty.defined_names)
 
     missingNR_df_old = access_missingNR_table(missingNR_df, version_cell)

--- a/src/migration_tool/tool.py
+++ b/src/migration_tool/tool.py
@@ -93,7 +93,9 @@ def migrate_workbook(
 
     old_wb_sheet_names = [sheet.title for sheet in old_wb_obj.worksheets]
 
-    df_old, sheets_issues = access_NR_table(old_wb_obj.defined_names, old_wb_sheet_names)
+    df_old, sheets_issues = access_NR_table(
+        old_wb_obj.defined_names, old_wb_sheet_names
+    )
     list_migrationissues.extend(sheets_issues)
     df_new, _ = access_NR_table(new_wb_empty.defined_names)
 


### PR DESCRIPTION
This pull request refactors the `access_NR_table` function to improve how name ranges and their issues are processed and returned, and updates its usage in the migration workflow. The main changes include simplifying the logic for extracting name range information, standardizing the return type for issues, and updating function parameters for clarity.

Helps with the migrator side of https://github.com/EFRAG-EU/Digital-Template-to-XBRL-Converter/issues/237

### Refactoring and Simplification

* Refactored `access_NR_table` in `src/migration_tool/outils.py` to use a single loop for extracting name range details, directly building a list of rows for the DataFrame and collecting issues in a unified list. This replaces the previous approach that used multiple lists and post-processing.
* Standardized the return value for issues: the function now always returns a list of issues (even if empty), removing the previous conditional logic that sometimes returned `None`.

### API and Usage Updates

* Renamed the parameter for the list of old sheet names from `sheets` to `old_sheet_names` for clarity, and updated all usages accordingly in both `outils.py` and `tool.py`. [[1]](diffhunk://#diff-eaf147ccd54cecc08185d4457782864da35f5692427394e5a2892c748f622a4dL47-R84) [[2]](diffhunk://#diff-a9dc2fb0a7625bd3ebb9ae6eab92f57951387e8f508c268d1919986aa8f8e144L94-R96)
* Updated the call to `access_NR_table` in `migrate_workbook` (in `src/migration_tool/tool.py`) to use the new parameter name and handle the updated return type for issues.

### Bug Fixes and Robustness

* Improved handling of name ranges with unreadable destinations or multiple destinations by logging issues and marking those entries as ignored in the migration, making the process more robust.…and update related references in migrate_workbook function